### PR TITLE
Upgrader shows a note when an old jasp file uses multigroup SEM

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,6 +20,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       R_REMOTES_UPGRADE: never
       VDIFFR_RUN_TESTS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -38,13 +38,6 @@ Upgrades
 			jsonValue:	"lavaan"
 		}
 
-		ChangeSetValue
-		{
-			name:		"showWarnTextInQml"
-			condition:	true // function(options) { return options["groupingVariable"] !== null; }
-			jsonValue:	true
-		}
-
 		ChangeRename { from: "model"; to: "models" }
 
 		ChangeJS

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -38,6 +38,13 @@ Upgrades
 			jsonValue:	"lavaan"
 		}
 
+		ChangeSetValue
+		{
+			name:		"showWarnTextInQml"
+			condition:	true // function(options) { return options["groupingVariable"] !== null; }
+			jsonValue:	true
+		}
+
 		ChangeRename { from: "model"; to: "models" }
 
 		ChangeJS

--- a/inst/qml/SEM.qml
+++ b/inst/qml/SEM.qml
@@ -26,6 +26,38 @@ Form
 	
 	columns: 1
 
+	// The following part is used for spawning upgrade notifications
+	CheckBox
+	{
+		id:			showWarnTextInQml
+		name:		"showWarnTextInQml"
+		visible:	false
+		checked:	false
+	}
+
+	Rectangle
+	{
+		visible:		myAnalysis !== null && showWarnTextInQml.checked && myAnalysis.needsRefresh
+		color:			jaspTheme.controlWarningBackgroundColor
+		width:			form.implicitWidth
+		height:			visible ? warningMessageUpdate.height : 0
+		//anchors.top:	parent.top
+		radius:			jaspTheme.borderRadius
+
+		Text
+		{
+			id:					warningMessageUpdate
+			text:				qsTr("This analysis was created with an older version of JASP (or a dynamic module). Since then, there were changes in the lavaan package that runs the analysis. Specifically, the lavaan syntax for equality constraints in multigroup analysis is now interpreted differently. Proceed with caution! More details about the update can be found at https://groups.google.com/g/lavaan/c/HSavF8oaW5M")
+			color:				jaspTheme.controlWarningTextColor
+			anchors.centerIn:	parent
+			padding:			5 * jaspTheme.uiScale
+			wrapMode:			Text.Wrap
+			width:				parent.width - 10 * jaspTheme.uiScale
+			verticalAlignment:	Text.AlignVCenter
+		}
+	}
+	// end upgrade notifications
+
 	TabView
 	{
 		id: models

--- a/inst/qml/SEM.qml
+++ b/inst/qml/SEM.qml
@@ -26,22 +26,13 @@ Form
 	
 	columns: 1
 
-	// The following part is used for spawning upgrade notifications
-	CheckBox
-	{
-		id:			showWarnTextInQml
-		name:		"showWarnTextInQml"
-		visible:	false
-		checked:	false
-	}
-
+	// The following part is used for spawning upgrade notifications about multigroup analysis
 	Rectangle
 	{
-		visible:		myAnalysis !== null && showWarnTextInQml.checked && myAnalysis.needsRefresh
+		visible:		myAnalysis !== null && myAnalysis.needsRefresh && grpvar.currentIndex !== 0 // if groupvar index is 0, there is no grouping variable -> no multigroup analysis
 		color:			jaspTheme.controlWarningBackgroundColor
 		width:			form.implicitWidth
-		height:			visible ? warningMessageUpdate.height : 0
-		//anchors.top:	parent.top
+		height:			warningMessageUpdate.height
 		radius:			jaspTheme.borderRadius
 
 		Text
@@ -49,7 +40,7 @@ Form
 			id:					warningMessageUpdate
 			text:				qsTr("This analysis was created with an older version of JASP (or a dynamic module). Since then, there were changes in the lavaan package that runs the analysis. Specifically, the lavaan syntax for equality constraints in multigroup analysis is now interpreted differently. Proceed with caution! More details about the update can be found at https://groups.google.com/g/lavaan/c/HSavF8oaW5M")
 			color:				jaspTheme.controlWarningTextColor
-			anchors.centerIn:	parent
+			anchors.top:		parent.top
 			padding:			5 * jaspTheme.uiScale
 			wrapMode:			Text.Wrap
 			width:				parent.width - 10 * jaspTheme.uiScale


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1369

and adds GITHUB_PAT for unit tests. Thanks @JorisGoosen for help with the anchoring!


This zip [oldsem.zip](https://github.com/jasp-stats/jaspSem/files/7007298/oldsem.zip) contains two jasp files. oldsem.jasp should show the note when loaded (as it uses multigroup analysis), oldsem-nogroup.jasp should not show the note.
