### PR TITLE
Removed redundant Beta labels of MIMIC and Latent Growth

### DIFF
--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -29,14 +29,14 @@ Description
 
 	Analysis
 	{
-		title:	qsTr("MIMIC Model (beta)")
+		title:	qsTr("MIMIC Model")
 		qml:	"Mimic.qml"
 		func:	"MIMIC"
 	}
 	
 	Analysis
 	{
-		title:	qsTr("Latent Growth (beta)")
+		title:	qsTr("Latent Growth")
 		qml:	"LatentGrowthCurve.qml"
 		func:	"LatentGrowthCurve"
 		//enabled: false


### PR DESCRIPTION
Removes the Beta tags of the Mimic and Latent Growth submodules of the SEM module. These aren't needed anymore as the modules are by now tested enough. 

Is this all there is needed to do, or does the tag need to be removed anywhere else?