### PR TITLE
Fail early when jackknife fails

### DIFF
--- a/R/plssem.R
+++ b/R/plssem.R
@@ -33,6 +33,7 @@ PLSSEMInternal <- function(jaspResults, dataset, options, ...) {
 
   # Output functions
   .plsSemFitTab(modelContainer, dataset, options, ready)
+  if (modelContainer$getError()) return()
   .plsSemParameters(modelContainer, dataset, options, ready)
   .plsSemRsquared(modelContainer, dataset, options, ready)
   .plsSemPrediction(modelContainer, options, ready)
@@ -154,7 +155,7 @@ checkCSemModel <- function(model, availableVars) {
     modelContainer <- createJaspContainer()
     modelContainer$dependOn(c("weightingApproach", "correlationMatrix", "convergenceCriterion",
                               "estimateStructural", "group", "correctionFactor", "compositeCorrelationDisattenuated",
-                              "structuralModelIgnored", "innerWeightingScheme", "errorCalculationMethod", "bootstrapSamples", "ciLevel",
+                              "structuralModelIgnored", "innerWeightingScheme", "errorCalculationMethod", "robustMethod", "bootstrapSamples", "ciLevel",
                               "setSeed", "seed", "handlingOfInadmissibles", "Data", "handlingOfFlippedSigns", "endogenousIndicatorPrediction",
                               "kFolds", "repetitions", "benchmark", "predictedScore"))
     jaspResults[["modelContainer"]] <- modelContainer


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/2449

also fixes the state issue that is mentioned in the issue.

Now we just forward whatever error message `cSEM` spits out, instead of having an `unexpected error` message. Not great, but for now it should be good enough 