### PR TITLE
more equality constraint enhancements

### DIFF
--- a/R/LatentGrowthCurveWrapper.R
+++ b/R/LatentGrowthCurveWrapper.R
@@ -39,7 +39,7 @@ LatentGrowthCurve <- function(
           group = "",
           impliedCovariance = FALSE,
           intercept = TRUE,
-          latentInterceptFixedToZero = TRUE,
+          latentMeanFixedToZero = TRUE,
           linear = TRUE,
           manifestInterceptFixedToZero = FALSE,
           misfitPlot = FALSE,

--- a/R/LatentGrowthCurveWrapper.R
+++ b/R/LatentGrowthCurveWrapper.R
@@ -39,7 +39,7 @@ LatentGrowthCurve <- function(
           group = "",
           impliedCovariance = FALSE,
           intercept = TRUE,
-          latentMeanFixedToZero = TRUE,
+          latentInterceptFixedToZero = TRUE,
           linear = TRUE,
           manifestInterceptFixedToZero = FALSE,
           misfitPlot = FALSE,

--- a/R/SEMWrapper.R
+++ b/R/SEMWrapper.R
@@ -46,7 +46,7 @@ SEM <- function(
           group = "",
           impliedCovariance = FALSE,
           informationMatrix = "expected",
-          latentMeanFixedToZero = TRUE,
+          latentInterceptFixedToZero = TRUE,
           manifestInterceptFixedToZero = FALSE,
           manifestMeanFixedToZero = FALSE,
           mardiasCoefficient = FALSE,

--- a/R/SEMWrapper.R
+++ b/R/SEMWrapper.R
@@ -46,7 +46,7 @@ SEM <- function(
           group = "",
           impliedCovariance = FALSE,
           informationMatrix = "expected",
-          latentInterceptFixedToZero = TRUE,
+          latentMeanFixedToZero = TRUE,
           manifestInterceptFixedToZero = FALSE,
           manifestMeanFixedToZero = FALSE,
           mardiasCoefficient = FALSE,

--- a/R/sem.R
+++ b/R/sem.R
@@ -204,7 +204,7 @@ checkLavaanModel <- function(model, availableVars) {
     modelContainer <- jaspResults[["modelContainer"]]
   } else {
     modelContainer <- createJaspContainer()
-    modelContainer$dependOn(c("samplingWeights", "meanStructure", "manifestInterceptFixedToZero", "latentMeanFixedToZero", "exogenousCovariateFixed", "orthogonal",
+    modelContainer$dependOn(c("samplingWeights", "meanStructure", "manifestInterceptFixedToZero", "latentInterceptFixedToZero", "exogenousCovariateFixed", "orthogonal",
                               "factorScaling", "residualSingleIndicatorOmitted", "residualVariance", "exogenousLatentCorrelation",
                               "dependentCorrelation", "threshold", "scalingParameter", "efaConstrained", "standardizedVariable", "naAction", "estimator", "test",
                               "errorCalculationMethod", "informationMatrix", "emulation", "group", "equalLoading", "equalIntercept",
@@ -360,7 +360,7 @@ checkLavaanModel <- function(model, availableVars) {
   # model features
   lavopts[["meanstructure"]]   <- options[["meanStructure"]]
   lavopts[["int.ov.free"]]     <- !options[["manifestInterceptFixedToZero"]]
-  lavopts[["int.lv.free"]]     <- !options[["latentMeanFixedToZero"]]
+  lavopts[["int.lv.free"]]     <- !options[["latentInterceptFixedToZero"]]
   lavopts[["fixed.x"]]         <- options[["exogenousCovariateFixed"]]
   lavopts[["orthogonal"]]      <- options[["orthogonal"]]
   lavopts[["std.lv"]]          <- options[["factorScaling"]] == "factorVariance"

--- a/R/sem.R
+++ b/R/sem.R
@@ -204,12 +204,12 @@ checkLavaanModel <- function(model, availableVars) {
     modelContainer <- jaspResults[["modelContainer"]]
   } else {
     modelContainer <- createJaspContainer()
-    modelContainer$dependOn(c("samplingWeights", "meanStructure", "manifestInterceptFixedToZero", "latentInterceptFixedToZero", "exogenousCovariateFixed", "orthogonal",
+    modelContainer$dependOn(c("samplingWeights", "meanStructure", "manifestInterceptFixedToZero", "latentMeanFixedToZero", "exogenousCovariateFixed", "orthogonal",
                               "factorScaling", "residualSingleIndicatorOmitted", "residualVariance", "exogenousLatentCorrelation",
                               "dependentCorrelation", "threshold", "scalingParameter", "efaConstrained", "standardizedVariable", "naAction", "estimator", "test",
                               "errorCalculationMethod", "informationMatrix", "emulation", "group", "equalLoading", "equalIntercept",
                               "equalResidual", "equalResidualCovariance", "equalMean", "equalThreshold", "equalRegression",
-                              "equalVariance", "equalLatentCovariance", "dataType", "sampleSize", "freeParameters", "manifestMeanFixedToZero"))
+                              "equalLatentVariance", "equalLatentCovariance", "dataType", "sampleSize", "freeParameters", "manifestMeanFixedToZero"))
     jaspResults[["modelContainer"]] <- modelContainer
   }
 
@@ -360,7 +360,7 @@ checkLavaanModel <- function(model, availableVars) {
   # model features
   lavopts[["meanstructure"]]   <- options[["meanStructure"]]
   lavopts[["int.ov.free"]]     <- !options[["manifestInterceptFixedToZero"]]
-  lavopts[["int.lv.free"]]     <- !options[["latentInterceptFixedToZero"]]
+  lavopts[["int.lv.free"]]     <- !options[["latentMeanFixedToZero"]]
   lavopts[["fixed.x"]]         <- options[["exogenousCovariateFixed"]]
   lavopts[["orthogonal"]]      <- options[["orthogonal"]]
   lavopts[["std.lv"]]          <- options[["factorScaling"]] == "factorVariance"
@@ -2362,7 +2362,7 @@ checkLavaanModel <- function(model, availableVars) {
   if (options[["group"]] != "")
     semModIndResult[["group"]] <- lavaan::lavInspect(fit, "group.label")[semModIndResult[["group"]]]
 
-  semModIndicesTable$setData(lapply(semModIndResult, .unv))
+  semModIndicesTable$setData(semModIndResult)
 
 
   if (!is.null(modelname)) {

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -118,7 +118,7 @@ Upgrades
 		}
 
 		ChangeRename {	from:	"fixManifestInterceptsToZero";	to:		"manifestInterceptFixedToZero"		}
-		ChangeRename {	from:	"fixLatentInterceptsToZero";	to:		"latentInterceptFixedToZero"		}
+		ChangeRename {	from:	"fixlatentMeansToZero";	to:		"latentMeanFixedToZero"		}
 		ChangeRename {	from:	"omitResidualSingleIndicator";	to:		"residualSingleIndicatorOmitted"	}
 		ChangeRename {	from:	"residualVariances";			to:		"residualVariance"					}
 		ChangeRename {	from:	"correlateExogenousLatents";	to:		"exogenousLatentCorrelation"		}
@@ -333,7 +333,7 @@ Upgrades
 
 		ChangeRename {	from:	"meanstructure";						to:		"meanStructure"						}
 		ChangeRename {	from:	"int.ov.fixed";							to:		"manifestInterceptFixedToZero"		}
-		ChangeRename {	from:	"int.lv.fixed";							to:		"latentInterceptFixedToZero"		}
+		ChangeRename {	from:	"int.lv.fixed";							to:		"latentMeanFixedToZero"		}
 		ChangeRename {	from:	"fixed.x";								to:		"exogenousCovariateFixed"			}
 		ChangeRename {	from:	"auto.fix.single";						to:		"residualSingleIndicatorOmitted"	}
 		ChangeRename {	from:	"auto.var";								to:		"residualVariance"					}

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -118,7 +118,7 @@ Upgrades
 		}
 
 		ChangeRename {	from:	"fixManifestInterceptsToZero";	to:		"manifestInterceptFixedToZero"		}
-		ChangeRename {	from:	"fixlatentMeansToZero";	to:		"latentMeanFixedToZero"		}
+		ChangeRename {	from:	"fixlatentInterceptsToZero";	to:		"latentInterceptFixedToZero"		}
 		ChangeRename {	from:	"omitResidualSingleIndicator";	to:		"residualSingleIndicatorOmitted"	}
 		ChangeRename {	from:	"residualVariances";			to:		"residualVariance"					}
 		ChangeRename {	from:	"correlateExogenousLatents";	to:		"exogenousLatentCorrelation"		}
@@ -333,7 +333,7 @@ Upgrades
 
 		ChangeRename {	from:	"meanstructure";						to:		"meanStructure"						}
 		ChangeRename {	from:	"int.ov.fixed";							to:		"manifestInterceptFixedToZero"		}
-		ChangeRename {	from:	"int.lv.fixed";							to:		"latentMeanFixedToZero"		}
+		ChangeRename {	from:	"int.lv.fixed";							to:		"latentInterceptFixedToZero"		}
 		ChangeRename {	from:	"fixed.x";								to:		"exogenousCovariateFixed"			}
 		ChangeRename {	from:	"auto.fix.single";						to:		"residualSingleIndicatorOmitted"	}
 		ChangeRename {	from:	"auto.var";								to:		"residualVariance"					}

--- a/inst/qml/LatentGrowthCurve.qml
+++ b/inst/qml/LatentGrowthCurve.qml
@@ -245,7 +245,7 @@ Form
 			title: qsTr("Options")
 			debug: true
 			CheckBox { text: qsTr("Fix manifest intercepts to zero") ; name: "manifestInterceptFixedToZero" 	}
-			CheckBox { text: qsTr("Fix latent intercepts to zero")   ; name: "latentMeanFixedToZero"		; checked: true }
+			CheckBox { text: qsTr("Fix latent intercepts to zero")   ; name: "latentInterceptFixedToZero"		; checked: true }
 			CheckBox { text: qsTr("Omit residual single indicator")  ; name: "residualSingleIndicatorOmitted"	; checked: true }
 			CheckBox { text: qsTr("Residual variances")              ; name: "residualVariance"           		; checked: true }
 			CheckBox { text: qsTr("Correlate exogenous latents")     ; name: "exogenousLatentCorrelation"   	; checked: true }

--- a/inst/qml/LatentGrowthCurve.qml
+++ b/inst/qml/LatentGrowthCurve.qml
@@ -245,7 +245,7 @@ Form
 			title: qsTr("Options")
 			debug: true
 			CheckBox { text: qsTr("Fix manifest intercepts to zero") ; name: "manifestInterceptFixedToZero" 	}
-			CheckBox { text: qsTr("Fix latent intercepts to zero")   ; name: "latentInterceptFixedToZero"		; checked: true }
+			CheckBox { text: qsTr("Fix latent intercepts to zero")   ; name: "latentMeanFixedToZero"		; checked: true }
 			CheckBox { text: qsTr("Omit residual single indicator")  ; name: "residualSingleIndicatorOmitted"	; checked: true }
 			CheckBox { text: qsTr("Residual variances")              ; name: "residualVariance"           		; checked: true }
 			CheckBox { text: qsTr("Correlate exogenous latents")     ; name: "exogenousLatentCorrelation"   	; checked: true }

--- a/inst/qml/SEM.qml
+++ b/inst/qml/SEM.qml
@@ -143,7 +143,7 @@ Form
 				]
 			}
 			CheckBox { name: "meanStructure";					label: qsTr("Include mean structure") ; checked: eq_intercepts.checked || eq_means.checked || eq_thresholds.checked
-				CheckBox { name: "latentMeanFixedToZero";		label: qsTr("Fix latent means to zero"); checked: !eq_means.checked }
+				CheckBox { name: "latentInterceptFixedToZero";		label: qsTr("Fix latent means to zero"); checked: !eq_means.checked }
 				CheckBox { name: "manifestInterceptFixedToZero";	label: qsTr("Fix manifest intercepts to zero"); }
 				CheckBox { name: "manifestMeanFixedToZero";		label: qsTr("Fix mean of manifest intercepts to zero")}
 			}

--- a/inst/qml/SEM.qml
+++ b/inst/qml/SEM.qml
@@ -81,63 +81,49 @@ Form
 		addEmptyValue: true
 	}
 
+
 	Section
 	{
-		title: qsTr("Output options")
-
+		title: qsTr("Multigroup SEM")
+		id: multigroup
 		Group
 		{
-			CheckBox { name: "additionalFitMeasures";	label: qsTr("Additional fit measures")				}
-			CheckBox { name: "rSquared";				label: qsTr("R-squared")							}
-			CheckBox { name: "ave";						label: qsTr("Average variance extracted (AVE)")		}
-			CheckBox { name: "htmt";					label: qsTr("Heterotrait-monotrait ratio (HTMT)")	}
-			CheckBox { name: "reliability";				label: qsTr("Reliability measures")					}
-			CheckBox { name: "observedCovariance";		label: qsTr("Observed covariances")					}
-			CheckBox { name: "impliedCovariance";		label: qsTr("Implied covariances")					}
-			CheckBox { name: "residualCovariance";		label: qsTr("Residual covariances")					}
-			CheckBox { name: "standardizedResidual"; 	label: qsTr("Standardized residuals")				}
-			CheckBox { name: "mardiasCoefficient";		label: qsTr("Mardia's coefficient")					}
-		}
-		Group
-		{
-			CheckBox{name: "standardizedEstimate"; label: qsTr("Standardized estimates"); checked: false}
-			CheckBox
+			DropDown
 			{
-				name: "pathPlot";
-				text: qsTr("Path diagram");
-				checked: false
-				CheckBox {
-					name: "pathPlotParameter"
-					text: qsTr("Show parameter estimates")
-					checked: false
-				}
-				CheckBox {
-					name: "pathPlotLegend"
-					text: qsTr("Show legend")
-					checked: false
-				}
-			}
-			CheckBox
+				id: grpvar
+				name: "group"
+				label: qsTr("Grouping Variable")
+				showVariableTypeIcon: true
+				addEmptyValue: true
+			} // No model or source: it takes all variables per default
+			Group
 			{
-				name: "modificationIndex"
-				label: qsTr("Modification indices")
-				CheckBox
-				{
-					name: "modificationIndexHiddenLow"
-					label: qsTr("Hide low indices")
-					DoubleField
-					{
-						name: "modificationIndexThreshold"
-						label: qsTr("Threshold")
-						negativeValues: false
-						decimals: 2
-						defaultValue: 10
-					}
-				}
+				visible: grpvar.value != ""
+				id: constraints
+				title: qsTr("Equality Constraints")
+				CheckBox { id: eq_loadings; 			name: "equalLoading";				label: qsTr("Loadings")				}
+				CheckBox { id: eq_intercepts; 			name: "equalIntercept";				label: qsTr("Intercepts")			}
+				CheckBox { id: eq_residuals; 			name: "equalResidual";				label: qsTr("Residuals")			}
+				CheckBox { id: eq_residualcovariances; 	name: "equalResidualCovariance";	label: qsTr("Residual covariances")	}
+				CheckBox { id: eq_means; 				name: "equalMean";					label: qsTr("Means")				}
+				CheckBox { id: eq_thresholds; 			name: "equalThreshold";				label: qsTr("Thresholds")			}
+				CheckBox { id: eq_regressions; 			name: "equalRegression";			label: qsTr("Regressions")			}
+				CheckBox { id: eq_variances; 			name: "equalLatentVariance";		label: qsTr("Latent variances")		}
+				CheckBox { id: eq_lvcovariances; 		name: "equalLatentCovariance";		label: qsTr("Latent covariances")	}
 			}
-		}
 
+		}
+		TextArea
+		{
+			name: "freeParameters"
+			title: qsTr("Release constraints (one per line)")
+			width: multigroup.width / 2
+			height: constraints.height + grpvar.height
+			textType: JASP.TextTypeLavaan
+			visible: eq_loadings.checked || eq_intercepts.checked || eq_residuals.checked || eq_residualcovariances.checked || eq_means.checked || eq_thresholds.checked || eq_regressions.checked || eq_variances.checked || eq_lvcovariances.checked
+		}
 	}
+
 
 	Section
 	{
@@ -156,10 +142,12 @@ Form
 					{ label: qsTr("None")				, value: "none"				}
 				]
 			}
-			CheckBox { name: "meanStructure";					label: qsTr("Include mean structure")							}
-			CheckBox { name: "latentInterceptFixedToZero";		label: qsTr("Fix latent intercepts to zero");	checked: true	}
-			CheckBox { name: "manifestInterceptFixedToZero";	label: qsTr("Fix manifest intercepts to zero")					}
-			CheckBox { name: "manifestMeanFixedToZero";		label: qsTr("Fix mean of manifest intercepts to zero")}
+			CheckBox { name: "meanStructure";					label: qsTr("Include mean structure") ; checked: eq_intercepts.checked || eq_means.checked || eq_thresholds.checked
+				CheckBox { name: "latentMeanFixedToZero";		label: qsTr("Fix latent means to zero"); checked: !eq_means.checked }
+				CheckBox { name: "manifestInterceptFixedToZero";	label: qsTr("Fix manifest intercepts to zero"); }
+				CheckBox { name: "manifestMeanFixedToZero";		label: qsTr("Fix mean of manifest intercepts to zero")}
+			}
+			
 			CheckBox { name: "orthogonal";						label: qsTr("Assume factors uncorrelated")						}
 		}
 
@@ -179,7 +167,7 @@ Form
 
 	Section
 	{
-		title: qsTr("Estimation options")
+		title: qsTr("Estimation Options")
 
 		Group
 		{
@@ -293,44 +281,60 @@ Form
 		}
 	}
 
-	Section
+Section
 	{
-		title: qsTr("Multigroup SEM")
-		id: multigroup
+		title: qsTr("Output Options")
+
 		Group
 		{
-			DropDown
-			{
-				id: grpvar
-				name: "group"
-				label: qsTr("Grouping Variable")
-				showVariableTypeIcon: true
-				addEmptyValue: true
-			} // No model or source: it takes all variables per default
-			Group
-			{
-				id: constraints
-				title: qsTr("Equality Constraints")
-				CheckBox { id: eq_loadings; 			name: "equalLoading";				label: qsTr("Loadings")				}
-				CheckBox { id: eq_intercepts; 			name: "equalIntercept";				label: qsTr("Intercepts")			}
-				CheckBox { id: eq_residuals; 			name: "equalResidual";				label: qsTr("Residuals")			}
-				CheckBox { id: eq_residualcovariances; 	name: "equalResidualCovariance";	label: qsTr("Residual covariances")	}
-				CheckBox { id: eq_means; 				name: "equalMean";					label: qsTr("Means")				}
-				CheckBox { id: eq_thresholds; 			name: "equalThreshold";				label: qsTr("Threshold")			}
-				CheckBox { id: eq_regressions; 			name: "equalRegression";			label: qsTr("Regressions")			}
-				CheckBox { id: eq_variances; 			name: "equalLatentVariance";		label: qsTr("Latent variances")		}
-				CheckBox { id: eq_lvcovariances; 		name: "equalLatentCovariance";		label: qsTr("Latent covariances")	}
-			}
-
+			CheckBox { name: "additionalFitMeasures";	label: qsTr("Additional fit measures")				}
+			CheckBox { name: "rSquared";				label: qsTr("R-squared")							}
+			CheckBox { name: "ave";						label: qsTr("Average variance extracted (AVE)")		}
+			CheckBox { name: "htmt";					label: qsTr("Heterotrait-monotrait ratio (HTMT)")	}
+			CheckBox { name: "reliability";				label: qsTr("Reliability measures")					}
+			CheckBox { name: "observedCovariance";		label: qsTr("Observed covariances")					}
+			CheckBox { name: "impliedCovariance";		label: qsTr("Implied covariances")					}
+			CheckBox { name: "residualCovariance";		label: qsTr("Residual covariances")					}
+			CheckBox { name: "standardizedResidual"; 	label: qsTr("Standardized residuals")				}
+			CheckBox { name: "mardiasCoefficient";		label: qsTr("Mardia's coefficient")					}
 		}
-		TextArea
+		Group
 		{
-			name: "freeParameters"
-			title: qsTr("Release constraints (one per line)")
-			width: multigroup.width / 2
-			height: constraints.height + grpvar.height
-			textType: JASP.TextTypeLavaan
-			visible: eq_loadings.checked || eq_intercepts.checked || eq_residuals.checked || eq_residualcovariances.checked || eq_means.checked || eq_thresholds.checked || eq_regressions.checked || eq_variances.checked || eq_lvcovariances.checked
+			CheckBox{name: "standardizedEstimate"; label: qsTr("Standardized estimates"); checked: false}
+			CheckBox
+			{
+				name: "pathPlot";
+				text: qsTr("Path diagram");
+				checked: false
+				CheckBox {
+					name: "pathPlotParameter"
+					text: qsTr("Show parameter estimates")
+					checked: false
+				}
+				CheckBox {
+					name: "pathPlotLegend"
+					text: qsTr("Show legend")
+					checked: false
+				}
+			}
+			CheckBox
+			{
+				name: "modificationIndex"
+				label: qsTr("Modification indices")
+				CheckBox
+				{
+					name: "modificationIndexHiddenLow"
+					label: qsTr("Hide low indices")
+					DoubleField
+					{
+						name: "modificationIndexThreshold"
+						label: qsTr("Threshold")
+						negativeValues: false
+						decimals: 2
+						defaultValue: 10
+					}
+				}
+			}
 		}
 	}
 }

--- a/tests/testthat/test-sem.R
+++ b/tests/testthat/test-sem.R
@@ -99,103 +99,7 @@ test_that("reliability/ AVE/ htmt works", {
                                    "total", 0.91494164193877, 0.919205517992938))
 })
 
-# Multigroup, multimodel SEM works
-options <- jaspTools::analysisOptions("SEM")
-options$emulation                   <-  "lavaan"
-options$estimator                   <- "default"
-options$group                       <- "group"
-options$informationMatrix           <- "expected"
-options$meanStructure               <- TRUE
-options$modificationIndexLowHidden  <- TRUE
-options$naAction                    <- "listwise"
-options$impliedCovariance           <- TRUE
-options$mardiasCoefficient          <- TRUE
-options$modificationIndex           <- TRUE
-options$observedCovariance          <- TRUE
-options$pathPlot                    <- TRUE
-options$rSquared                    <- TRUE
-options$residualCovariance          <- TRUE
-options$standardizedResidual        <- TRUE
-options$pathPlotParameter           <- TRUE
-options$standardizedEstimate        <- TRUE
-options$latentMeanFixedToZero  <- TRUE
-options$modelTest                   <- "satorraBentler"
-options$samplingWeights             <- ""
 
-modelDefault <- list(model = "
-# latent variable definitions
-  ind60 =~ x1 + x2 + x3
-  dem60 =~ y1 + y2 + y3 + y4
-  dem65 =~ y5 + y6 + y7 + y8
-# regressions
-  dem60 ~ ind60
-  dem65 ~ ind60 + dem60
-# residual (co)variances
-  y1 ~~ y5
-  y2 ~~ y4 + y6
-  y3 ~~ y7
-  y4 ~~ y8
-  y6 ~~ y8
-", columns = c("x1", "x2", "x3", "y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8"))
-modelConstrained <- list(model = "
-# latent variable definitions
-  ind60 =~ x1 + x2 + x3
-  dem60 =~ c(a1,a2)*y1 + c(b1,b2)*y2 + c(c1,c2)*y3 + c(d1,d2)*y4
-  dem65 =~ c(a1,a3)*y5 + c(b1,b3)*y6 + c(c1,c3)*y7 + c(d1,d3)*y8
-# regressions
-  dem60 ~ ind60
-  dem65 ~ ind60 + dem60
-# residual (co)variances
-  y1 ~~ y5
-  y2 ~~ y4 + y6
-  y3 ~~ y7
-  y4 ~~ y8
-  y6 ~~ y8
-", columns = c("x1", "x2", "x3", "y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8"))
-modelMoreConstrained <- list(model = "
-# latent variable definitions
-  ind60 =~ x1 + x2 + x3
-  dem60 =~ c(a1, a2)*y1 + c(b1, b2)*y2 + c(c1, c2)*y3 + c(d1, d2)*y4
-  dem65 =~ c(a1, a2)*y5 + c(b1, b2)*y6 + c(c1, c2)*y7 + c(d1, d2)*y8
-# regressions
-  dem60 ~ ind60
-  dem65 ~ ind60 + dem60
-# residual (co)variances
-  y1 ~~ y5
-  y2 ~~ y4 + y6
-  y3 ~~ y7
-  y4 ~~ y8
-  y6 ~~ y8
-", columns = c("x1", "x2", "x3", "y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8"))
-
-options$models = list(
-  list(name = "default",          syntax = modelDefault),
-  list(name = "constrained",      syntax = modelConstrained),
-  list(name = "more constrained", syntax = modelMoreConstrained)
-)
-
-results <- jaspTools::runAnalysis("SEM", "poldem_grouped.csv", options)
-
-
-test_that("Model fit table results match", {
-  table <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_fittab"]][["data"]]
-  jaspTools::expect_equal_tables(table,
-                                 list(3189.26691715401, 3383.93591869106, 85.6796813843018, 70, "default",
-                                      75, 0.0980338951401478, "", "", "", "all", 3184.34803034567,
-                                      3372.06456754211, 87.9549367720082, 73, "constrained", 75, 0.111927575441416,
-                                      0.647754490400887, 1.65156784896069, 3, "all", 3181.07183366569,
-                                      3361.83590652152, 92.7433708195334, 76, "more constrained",
-                                      75, 0.0929761753674234, 0.110596895611682, 6.02091896548516,
-                                      3, "all", 1638.81154499845, 1774.12864966057, 51.6035277328312,
-                                      "", "default", 37, "", "", "", "", 1, 1718.45537215556, 1856.01260957258,
-                                      34.0761536514705, "", "default", 38, "", "", "", "", 2, 1633.89265814398,
-                                      1764.37700906817, 53.4279668719259, "", "constrained", 37, "",
-                                      "", "", "", 1, 1712.45537220169, 1845.09985113953, 34.5269699000823,
-                                      "", "constrained", 38, "", "", "", "", 2, 1627.89265813238,
-                                      1753.54425531862, 54.5525537466071, "", "more constrained",
-                                      37, "", "", "", "", 1, 1709.17917553332, 1836.91089599197, 38.1908170729263,
-                                      "", "more constrained", 38, "", "", "", "", 2))
-})
 
 test_that("Multigroup, multimodel SEM works", {
   options <- jaspTools::analysisOptions("SEM")
@@ -216,6 +120,7 @@ test_that("Multigroup, multimodel SEM works", {
   options$standardizedResidual        = TRUE
   options$pathPlotParameter           = TRUE
   options$standardizedEstimate        = TRUE
+  options$latentInterceptFixedToZero <- TRUE
   options$modelTest                   = "satorraBentler"
   options$samplingWeights             = ""
 

--- a/tests/testthat/test-sem.R
+++ b/tests/testthat/test-sem.R
@@ -53,45 +53,43 @@ test_that("Basic SEM covariance parameter table works", {
                                    "y1", 6.78685155555555, "", "y1", "", 0, ""))
 })
 
+
+# Reliability, AVE, HTMT works
+options <- jaspTools::analysisOptions("SEM")
+options$models <- list(list(name = "Model1", syntax = list(model = "
+# latent variable definitions
+  ind60 =~ x1 + x2 + x3
+  dem60 =~ y1 + y2 + y3 + y4
+  dem65 =~ y5 + y6 + y7 + y8
+# regressions
+  dem60 ~ ind60
+  dem65 ~ ind60 + dem60
+# residual (co)variances
+  y1 ~~ y5
+  y2 ~~ y4 + y6
+  y3 ~~ y7
+  y4 ~~ y8
+  y6 ~~ y8
+", columns = c("x1", "x2", "x3", "y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8"))))
+options$emulation         <- "lavaan"
+options$estimator         <- "default"
+options$group             <- ""
+options$samplingWeights   <- ""
+options$informationMatrix <- "expected"
+options$naAction          <- "fiml"
+options$modelTest         <- "standard"
+options$reliability       <- TRUE
+options$ave               <- TRUE
+options$htmt              <- TRUE
+results <- jaspTools::runAnalysis("SEM", "poldem_grouped.csv", options)
+
+
+container   <- results[["results"]][["modelContainer"]][["collection"]]
+ave         <- container[["modelContainer_AVE"]][["data"]]
+htmt        <- container[["modelContainer_htmt"]][["collection"]][["modelContainer_htmt_htmttab"]][["data"]]
+reliability <- container[["modelContainer_reliability"]][["data"]]
+
 test_that("reliability/ AVE/ htmt works", {
-  options <- jaspTools::analysisOptions("SEM")
-  options$models <- list(list(name = "Model1", syntax = list(model = "
-  # latent variable definitions
-    ind60 =~ x1 + x2 + x3
-    dem60 =~ y1 + y2 + y3 + y4
-    dem65 =~ y5 + y6 + y7 + y8
-  # regressions
-    dem60 ~ ind60
-    dem65 ~ ind60 + dem60
-  # residual (co)variances
-    y1 ~~ y5
-    y2 ~~ y4 + y6
-    y3 ~~ y7
-    y4 ~~ y8
-    y6 ~~ y8
-  ", columns = c("x1", "x2", "x3", "y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8"))))
-  options$emulation         <- "lavaan"
-  options$estimator         <- "default"
-  options$group             <- ""
-  options$samplingWeights   <- ""
-  options$informationMatrix <- "expected"
-  options$naAction          <- "fiml"
-  options$modelTest         <- "standard"
-  options$reliability       <- TRUE
-  options$ave               <- TRUE
-  options$htmt              <- TRUE
-  results <- jaspTools::runAnalysis("SEM", "poldem_grouped.csv", options)
-
-  fittab   <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_fittab"]][["data"]]
-  expect_equal_tables(fittab, list(3179.58214617614, 3276.91664694466, 38.1251848056502, 35, "Model1",
-                                   75, 0.329181716488409, 0.329181716488409, 38.1251848056502,
-                                   35), "Model fit table")
-
-  container   <- results[["results"]][["modelContainer"]][["collection"]]
-  ave         <- container[["modelContainer_AVE"]][["data"]]
-  htmt        <- container[["modelContainer_htmt"]][["collection"]][["modelContainer_htmt_htmttab"]][["data"]]
-  reliability <- container[["modelContainer_reliability"]][["data"]]
-
   expect_equal_tables(ave, list(0.8588015398276, "ind60", 0.597128239158634, "dem60", 0.640021072526866,
                                    "dem65"))
   expect_equal_tables(htmt, list("", "", 1, 1, "", 0.420934414880351, 0.980709420149052, 1, 0.549916280338394
@@ -99,6 +97,104 @@ test_that("reliability/ AVE/ htmt works", {
   expect_equal_tables(reliability, list("ind60", 0.902334680203148, 0.943690008441057, "dem60", 0.858794528217608,
                                    0.841179471771507, "dem65", 0.882739385479519, 0.857553923970666,
                                    "total", 0.91494164193877, 0.919205517992938))
+})
+
+# Multigroup, multimodel SEM works
+options <- jaspTools::analysisOptions("SEM")
+options$emulation                   <-  "lavaan"
+options$estimator                   <- "default"
+options$group                       <- "group"
+options$informationMatrix           <- "expected"
+options$meanStructure               <- TRUE
+options$modificationIndexLowHidden  <- TRUE
+options$naAction                    <- "listwise"
+options$impliedCovariance           <- TRUE
+options$mardiasCoefficient          <- TRUE
+options$modificationIndex           <- TRUE
+options$observedCovariance          <- TRUE
+options$pathPlot                    <- TRUE
+options$rSquared                    <- TRUE
+options$residualCovariance          <- TRUE
+options$standardizedResidual        <- TRUE
+options$pathPlotParameter           <- TRUE
+options$standardizedEstimate        <- TRUE
+options$latentMeanFixedToZero  <- TRUE
+options$modelTest                   <- "satorraBentler"
+options$samplingWeights             <- ""
+
+modelDefault <- list(model = "
+# latent variable definitions
+  ind60 =~ x1 + x2 + x3
+  dem60 =~ y1 + y2 + y3 + y4
+  dem65 =~ y5 + y6 + y7 + y8
+# regressions
+  dem60 ~ ind60
+  dem65 ~ ind60 + dem60
+# residual (co)variances
+  y1 ~~ y5
+  y2 ~~ y4 + y6
+  y3 ~~ y7
+  y4 ~~ y8
+  y6 ~~ y8
+", columns = c("x1", "x2", "x3", "y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8"))
+modelConstrained <- list(model = "
+# latent variable definitions
+  ind60 =~ x1 + x2 + x3
+  dem60 =~ c(a1,a2)*y1 + c(b1,b2)*y2 + c(c1,c2)*y3 + c(d1,d2)*y4
+  dem65 =~ c(a1,a3)*y5 + c(b1,b3)*y6 + c(c1,c3)*y7 + c(d1,d3)*y8
+# regressions
+  dem60 ~ ind60
+  dem65 ~ ind60 + dem60
+# residual (co)variances
+  y1 ~~ y5
+  y2 ~~ y4 + y6
+  y3 ~~ y7
+  y4 ~~ y8
+  y6 ~~ y8
+", columns = c("x1", "x2", "x3", "y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8"))
+modelMoreConstrained <- list(model = "
+# latent variable definitions
+  ind60 =~ x1 + x2 + x3
+  dem60 =~ c(a1, a2)*y1 + c(b1, b2)*y2 + c(c1, c2)*y3 + c(d1, d2)*y4
+  dem65 =~ c(a1, a2)*y5 + c(b1, b2)*y6 + c(c1, c2)*y7 + c(d1, d2)*y8
+# regressions
+  dem60 ~ ind60
+  dem65 ~ ind60 + dem60
+# residual (co)variances
+  y1 ~~ y5
+  y2 ~~ y4 + y6
+  y3 ~~ y7
+  y4 ~~ y8
+  y6 ~~ y8
+", columns = c("x1", "x2", "x3", "y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8"))
+
+options$models = list(
+  list(name = "default",          syntax = modelDefault),
+  list(name = "constrained",      syntax = modelConstrained),
+  list(name = "more constrained", syntax = modelMoreConstrained)
+)
+
+results <- jaspTools::runAnalysis("SEM", "poldem_grouped.csv", options)
+
+
+test_that("Model fit table results match", {
+  table <- results[["results"]][["modelContainer"]][["collection"]][["modelContainer_fittab"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list(3189.26691715401, 3383.93591869106, 85.6796813843018, 70, "default",
+                                      75, 0.0980338951401478, "", "", "", "all", 3184.34803034567,
+                                      3372.06456754211, 87.9549367720082, 73, "constrained", 75, 0.111927575441416,
+                                      0.647754490400887, 1.65156784896069, 3, "all", 3181.07183366569,
+                                      3361.83590652152, 92.7433708195334, 76, "more constrained",
+                                      75, 0.0929761753674234, 0.110596895611682, 6.02091896548516,
+                                      3, "all", 1638.81154499845, 1774.12864966057, 51.6035277328312,
+                                      "", "default", 37, "", "", "", "", 1, 1718.45537215556, 1856.01260957258,
+                                      34.0761536514705, "", "default", 38, "", "", "", "", 2, 1633.89265814398,
+                                      1764.37700906817, 53.4279668719259, "", "constrained", 37, "",
+                                      "", "", "", 1, 1712.45537220169, 1845.09985113953, 34.5269699000823,
+                                      "", "constrained", 38, "", "", "", "", 2, 1627.89265813238,
+                                      1753.54425531862, 54.5525537466071, "", "more constrained",
+                                      37, "", "", "", "", 1, 1709.17917553332, 1836.91089599197, 38.1908170729263,
+                                      "", "more constrained", 38, "", "", "", "", 2))
 })
 
 test_that("Multigroup, multimodel SEM works", {


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-issues/issues/2225
as pointed out by the very valuable contribution of @HeikoBreitsohl I implemented the following changes: 
- reorder the sections
- fix the bugs with the erroneous constraints and missing constraints
- equality constraints are only shown if a group variable is selected 
- meanstructure is automatically checked if equality constraints are put on either intercepts, means or thresholds
- if equality constraints are put on means the by default checked box of "fix latent intercepts to zero" is unchecked. For other conditions the box remains checked by default given this is also the lavaan standard setting and often useful for identification