### PR TITLE
Fix some bugs regarding standardization 

### DIFF
--- a/R/mediationanalysis.R
+++ b/R/mediationanalysis.R
@@ -111,9 +111,10 @@ MediationAnalysisInternal <- function(jaspResults, dataset, options, ...) {
     model           = .medToLavMod(options),
     data            = dataset,
     se              = ifelse(options$errorCalculationMethod == "bootstrap", "standard", options$errorCalculationMethod),
+    std.ov          = options$standardizedEstimate,
+    fixed.x         = !options$standardizedEstimate,
     mimic           = options$emulation,
     estimator       = options$estimator,
-    std.ov          = options$standardizedEstimate,
     missing         = options$naAction
   ))
 

--- a/R/sem.R
+++ b/R/sem.R
@@ -271,9 +271,17 @@ checkLavaanModel <- function(model, availableVars) {
       lav_args[["model"]] <- originalSyntax
     }
     if (options[["dataType"]] == "raw") {
-      lav_args[["data"]]  <- dataset
+      if (options[["standardizedVariable"]]) {
+        dataset <- scale(dataset)
+      }
+      lav_args[["data"]] <- dataset
+
     } else {
-      lav_args[["sample.cov"]] <- .semDataCovariance(dataset, options[["models"]][[i]][["syntax"]])
+      cov_mat <- .semDataCovariance(dataset, options[["models"]][[i]][["syntax"]])
+      if (options[["standardizedVariable"]]) {
+        cov_mat <- stats::cov2cor(cov_mat)
+      }
+      lav_args[["sample.cov"]] <- cov_mat
       lav_args[["sample.nobs"]] <- options[["sampleSize"]]
     }
 
@@ -385,7 +393,6 @@ checkLavaanModel <- function(model, availableVars) {
   lavopts[["auto.efa"]]        <- options[["efaConstrained"]]
 
   # data options
-  lavopts[["std.ov"]]  <- options[["standardizedVariable"]]
   lavopts[["missing"]] <- ifelse(options[["naAction"]] == "fiml", "ml",
                                  ifelse(options[["naAction"]] == "twoStage", "two.stage",
                                         ifelse(options[["naAction"]] == "twoStageRobust", "robust.two.stage",


### PR DESCRIPTION
fixes an issue with pre-estimation standardisation that was done in SEM
fixes, kind of, https://github.com/jasp-stats/jasp-issues/issues/2740

The issue is that for true standardized estimates especially in mediation, we need post-estimation standardisation. That would ideally work through `standardizedSolution` in lavaan. However, for a bootstrapped sample of models that does not produce the CIs we want. So it might make sense do implement something ourselves. 
There is already the need to have the CIs also for standardized estimates in SEM, which we do not offer. 