### PR TITLE
MNLFA: reduce redundant TabView model resets

### DIFF
--- a/inst/qml/ModeratedNonLinearFactorAnalysis.qml
+++ b/inst/qml/ModeratedNonLinearFactorAnalysis.qml
@@ -189,6 +189,9 @@ Form
 
 		property var firstLayerValues: [invarianceTestConfigural, invarianceTestMetric, invarianceTestScalar, invarianceTestStrict, invarianceTestCustom].filter(x => x.checked).map(x => ({value: x.name, label: x.label}))
 
+		// only re-evaluate third-layer values when the factor COUNT changes, not on every factorsTitles mutation (rename, indicators)
+		readonly property int factorCount: factors.factorsTitles.length
+
 		TabView
 		{
 			Layout.columnSpan: 1
@@ -221,7 +224,7 @@ Form
 					addItemManually: false
 					optionKey: "keyValue"
 					optionKeyLabel: "keyLabel"
-					values: getValuesModOptions(rowValue, factors.factorsTitles.length)
+					values: getValuesModOptions(rowValue, invOpts.factorCount)
 					rowComponent: ComponentsList
 					{
 						id: modFourthLayer
@@ -338,7 +341,7 @@ Form
 					name: "plotParameterList"
 					addItemManually: false
 
-					values: getValuesModOptions(rowValue, factors.factorsTitles.length)
+					values: getValuesModOptions(rowValue, invOpts.factorCount)
 
 					rowComponent: ComponentsList
 					{


### PR DESCRIPTION
## What

MNLFA hardening: third-layer TabView `values:` now depend on a cached `factorCount` int property instead of the `factorsTitles` array, so tab models only reset when the factor **count** changes — not on every rename/indicator change.

## Why

The nested TabViews in MNLFA intermittently collapse to zero height. Root cause is a stale height binding in jasp-desktop's TabView after model resets — fixed in jasp-stats/jasp-desktop#6295. This PR complements it by removing redundant reset triggers on the module side.

No option `name:` changes → no Upgrades.qml migration. All 12 MNLFA tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
